### PR TITLE
fix dropdown list filtering in gridview, when gridview inserted with …

### DIFF
--- a/framework/widgets/Pjax.php
+++ b/framework/widgets/Pjax.php
@@ -186,7 +186,7 @@ class Pjax extends Widget
             $js .= "jQuery(document).pjax($linkSelector, \"#$id\", $options);";
         }
         if ($this->formSelector !== false) {
-            $formSelector = Json::htmlEncode($this->formSelector !== null ? $this->formSelector : '#' . $id . ' form[data-pjax]');
+            $formSelector = Json::htmlEncode($this->formSelector !== null ? $this->formSelector : 'form[data-pjax]');
             $js .= "\njQuery(document).on('submit', $formSelector, function (event) {jQuery.pjax.submit(event, '#$id', $options);});";
         }
         $view = $this->getView();


### PR DESCRIPTION
When GridView ([/some_grid_view]  route) (surrounded by Pjax widget) inserted in page (for example in Tab widget [/tab_with_gridview route]), then  dropdown list filter sending request without pjax, and page redirecting to [ /some_grid_view route].

It's happen because, Pjax generate listeners for element $('#some_grid_id form[data-pjax]'), but yii.gridView.js create form in "root" DOM, so event listener not catch form.submit event.